### PR TITLE
Added maintainer to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,6 +6,7 @@
   <description>
     Check Locus Robotics-specific copyright headers.
   </description>
+  <maintainer email="planning-and-control@locusrobotics.com">Planning And Control</maintainer>
   <license>BSD</license>
 
   <exec_depend>ament_copyright</exec_depend>


### PR DESCRIPTION
- We need to add a maintainer in order for colcon not to throw a warning

P.S. This will help my bash code completion function (just runs `colcon list`) list all locus_nav2 packages correctly without throwing a warning.